### PR TITLE
replace lr argument in reset_learning_rate

### DIFF
--- a/main_utils.py
+++ b/main_utils.py
@@ -25,7 +25,7 @@ def adjust_learning_rate(optimizer, epoch, args):
         lr = max(lr, args.lr_clip)
     # logger.log('lr: ' + str(lr))
 
-    reset_learning_rate(optimizer, lr)
+    reset_learning_rate(optimizer, args)
     # for param_group in optimizer.param_groups:
     #     param_group['lr'] = lr
 


### PR DESCRIPTION
Replace the argument for learning rate in reset_learning_rate in line 29 with args as it throws an error otherwise. The function expects the argument to be easydict and not the float value of learning rate.